### PR TITLE
feat: modify production url for cloudfront-vpc_origin #46

### DIFF
--- a/src/config/api.config.ts
+++ b/src/config/api.config.ts
@@ -1,112 +1,115 @@
 export interface ApiConfig {
-  BASE_URL: string;
-  TIMEOUT: number;
-  ENDPOINTS: {
-    AUTH: string;
-    ADMIN_AUTH: string;
-    USERS: string;
-    PERFORMANCES: string;
-    ADMIN_PERFORMANCES: string;
-    BOOKINGS: string;
-    ADMIN_BOOKINGS: string;
-    VENUES: string;
-    SYSTEM: string;
-    QUEUE: string;
-    SEATS: string;
-    ASG: string;
-    ASG_OVERVIEW: string;
-  };
-  MOCK_ENDPOINTS?: string[];
+    BASE_URL: string;
+    TIMEOUT: number;
+    ENDPOINTS: {
+        AUTH: string;
+        ADMIN_AUTH: string;
+        USERS: string;
+        PERFORMANCES: string;
+        ADMIN_PERFORMANCES: string;
+        BOOKINGS: string;
+        ADMIN_BOOKINGS: string;
+        VENUES: string;
+        SYSTEM: string;
+        QUEUE: string;
+        SEATS: string;
+        ASG: string;
+        ASG_OVERVIEW: string;
+    };
+    MOCK_ENDPOINTS?: string[];
 }
 
 //todo: 개발 중 변경
 const development: ApiConfig = {
-  BASE_URL: "http://localhost:8080",
-  TIMEOUT: 10000,
-  ENDPOINTS: {
-    AUTH: "/auth",
-    ADMIN_AUTH: "/admin/auth",
-    USERS: "/v1/admin/users",
-    PERFORMANCES: "/v1/performances",
-    ADMIN_PERFORMANCES: "/v1/admin/performances",
-    ADMIN_BOOKINGS: "/v1/admin/bookings",
-    BOOKINGS: "/api/bookings",
-    VENUES: "/api/venues",
-    SYSTEM: "/api/system",
-    QUEUE: "/api/v1/queue",
-    SEATS: "/api/v1",
-  },
-  MOCK_ENDPOINTS: [],
+    BASE_URL: 'http://localhost:8080',
+    TIMEOUT: 10000,
+    ENDPOINTS: {
+        AUTH: '/auth',
+        ADMIN_AUTH: '/admin/auth',
+        USERS: '/v1/admin/users',
+        PERFORMANCES: '/v1/performances',
+        ADMIN_PERFORMANCES: '/v1/admin/performances',
+        ADMIN_BOOKINGS: '/v1/admin/bookings',
+        BOOKINGS: '/api/bookings',
+        VENUES: '/api/venues',
+        SYSTEM: '/api/system',
+        QUEUE: '/api/v1/queue',
+        SEATS: '/api/v1',
+    },
+    MOCK_ENDPOINTS: [],
 };
 
 const production: ApiConfig = {
-  BASE_URL: "https://staging-api.yourticketservice.com",
-  TIMEOUT: 10000,
-  ENDPOINTS: {
-    AUTH: "/auth",
-    ADMIN_AUTH: "/admin/auth",
-    USERS: "/v1/admin/users",
-    PERFORMANCES: "/v1/performances",
-    ADMIN_PERFORMANCES: "/v1/admin/performances",
-    BOOKINGS: "/api/bookings",
-    ADMIN_BOOKINGS: "/v1/admin/bookings",
-    VENUES: "/api/venues",
-    SYSTEM: "/api/system",
-    QUEUE: "/api/v1/queue",
-    SEATS: "/api/v1",
-  },
-  MOCK_ENDPOINTS: [],
+    BASE_URL: 'https://api.ddcn41.com',
+    TIMEOUT: 10000,
+    ENDPOINTS: {
+        AUTH: '/auth',
+        ADMIN_AUTH: '/admin/auth',
+        USERS: '/v1/admin/users',
+        PERFORMANCES: '/v1/performances',
+        ADMIN_PERFORMANCES: '/v1/admin/performances',
+        ADMIN_BOOKINGS: '/v1/admin/bookings',
+        BOOKINGS: '/api/bookings',
+        VENUES: '/api/venues',
+        SYSTEM: '/api/system',
+        QUEUE: '/api/v1/queue',
+        SEATS: '/api/v1',
+    },
+    MOCK_ENDPOINTS: [],
 };
 
 // 현재 환경 감지
 const getCurrentEnvironment = (): string => {
-  const hostname = window.location.hostname;
+    const hostname = window.location.hostname;
 
-  if (hostname === "localhost") {
-    return "development";
-  }
-  return "production";
+    if (hostname === 'localhost') {
+        return 'development';
+    }
+    return 'production';
 };
 
 // 환경별 설정 반환
 const getConfig = (): ApiConfig => {
-  const env = getCurrentEnvironment();
+    const env = getCurrentEnvironment();
 
-  switch (env) {
-    case "development":
-      return development;
-    case "production":
-      return production;
-    default:
-      return development;
-  }
+    switch (env) {
+        case 'development':
+            return development;
+        case 'production':
+            return production;
+        default:
+            return development;
+    }
 };
 export const API_CONFIG = getConfig();
 
 // Mock 사용 여부를 확인하는 헬퍼 함수
 export const shouldUseMock = (
-  endpoint: keyof ApiConfig["ENDPOINTS"]
+    endpoint: keyof ApiConfig['ENDPOINTS']
 ): boolean => {
-  if (typeof window !== 'undefined') {
-    try {
-      const override = localStorage.getItem('forceMockMode');
-      if (override === 'true') {
-        return true;
-      }
-      if (override === 'false') {
-        return false;
-      }
-    } catch (error) {
-      console.warn('Unable to read forceMockMode from localStorage', error);
+    if (typeof window !== 'undefined') {
+        try {
+            const override = localStorage.getItem('forceMockMode');
+            if (override === 'true') {
+                return true;
+            }
+            if (override === 'false') {
+                return false;
+            }
+        } catch (error) {
+            console.warn(
+                'Unable to read forceMockMode from localStorage',
+                error
+            );
+        }
     }
-  }
 
-  return API_CONFIG.MOCK_ENDPOINTS?.includes(endpoint) ?? false;
+    return API_CONFIG.MOCK_ENDPOINTS?.includes(endpoint) ?? false;
 };
 
 // 개발자 도구 (개발 환경에서만)
 if (process.env.NODE_ENV === 'development') {
-  (window as any).apiDebug = {
-    showConfig: () => console.table(API_CONFIG),
-  };
+    (window as any).apiDebug = {
+        showConfig: () => console.table(API_CONFIG),
+    };
 }


### PR DESCRIPTION
### PR 타입(아래 중 하나 이상을 고른 뒤 나머지는 삭제)

- Feat : 새로운 기능 추가

### 반영 브랜치
feat/#46

### 변경 사항
#46

prodction 환경에서 자동 ApiConfig가 잘 동작하는 것을 확인, 해당 url을 cloudfront에 맞게 변경

### 테스트 결과
<img width="1064" height="908" alt="image" src="https://github.com/user-attachments/assets/85b6bc54-8f79-43dd-b883-c5e79ffded1c" />